### PR TITLE
Add types for symbol methods

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -66,7 +66,10 @@ export type Remote<T> =
     T extends boolean
       ? Promise<boolean>
       : unknown
-  );
+  ) & {
+    [createEndpoint]: MessagePort;
+    [releaseProxy]: () => void;
+  };
 
 declare var x: Remote<number>;
 


### PR DESCRIPTION
Tried to use these in some TypeScript and they appeared to be untyped. These changes seem to fix the issues!